### PR TITLE
Add support for combining multiple scenes into single presentation and migrate to new API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .vscode
 __pycache__
+temporary

--- a/pptx_export/addon.py
+++ b/pptx_export/addon.py
@@ -39,6 +39,11 @@ class Addon:
                 "flag": "--anti_dupli_pptx",
                 "action": "store_true",
                 "help": f"[{Addon.PACKAGE_NAME}] When exporting to PowerPoint, only use every other movie part"
+            },
+            {
+                "flag": "--join_scenes_pptx",
+                "action": "store_false",
+                "help": f"[{Addon.PACKAGE_NAME}] Combines the scenes into a single PowerPoint presentation"
             }
         ]
     
@@ -53,29 +58,34 @@ class Addon:
 
     def on_rendered(self, scene_classes):
         # Fires when a video is finished rendering
-        if self.config["all_args"].save_to_pptx:
-            for scene_class in scene_classes:
-                self.create_ppt(scene_class.__name__)
+        args = self.config["all_args"]
+        if args.save_to_pptx:
+            if args.join_scenes_pptx:
+                for scene_class in scene_classes:
+                    name = scene_class.__name__
+                    self.create_ppt([name], name)
+            else:
+                self.create_ppt([scene_class.__name__ for scene_class in scene_classes], "Scenes")
 
-    def create_ppt(self, scene_name):
+    def create_ppt(self, scene_names, ppt_name):
         SLD_BLANK = 6
         if not os.path.exists(Addon.TEMPORARY_DIR):
             os.makedirs(Addon.TEMPORARY_DIR)
         if os.path.exists(Addon.LOG_DIR):
             os.remove(Addon.LOG_DIR)
-        prs = Presentation(self.TEMPLATE_PPTX)
+        prs = Presentation(Addon.TEMPLATE_PPTX)
         
         # Figure out where the movie parts are saved
-        PART_DIR = os.path.join(os.path.dirname(manimlib.addon_helper.movie_paths[0]), "partial_movie_files", scene_name)
-        self.log_line("PART_DIR = " + PART_DIR)
-        parts = sorted(glob.glob(os.path.join(PART_DIR, "*.mp4")))
-        read_parts = PART_DIR
+        PART_DIRS = [os.path.join(os.path.dirname(manimlib.addon_helper.movie_paths[0]), "partial_movie_files", scene_name) for scene_name in scene_names]
+        self.log_line(f"PART_DIRS = {PART_DIRS}")
+        parts = [sorted(glob.glob(os.path.join(part_dir, "*.mp4"))) for part_dir in PART_DIRS]
+        read_parts = PART_DIRS
 
         # Go through each video part and copy it over to the temporary directory.
         # If anti-duplicate is on, every other part is combined with the one before it and then copied over to the temp directory
         if self.config["all_args"].anti_dupli_pptx:
             self.log_line("Anti-duplication manually enabled")
-            read_parts = Addon.TEMPORARY_DIR
+            read_parts = [Addon.TEMPORARY_DIR]
             for file in parts:
                 i = int(self.get_name(file))
                 if not i % 2 == 0:
@@ -83,46 +93,47 @@ class Addon:
                     merged_clip = self.merge_videos(parts[i-1], file, os.path.join(Addon.TEMPORARY_DIR, str(i-1).zfill(5) + ".mp4"))
                     self.log_line("Merged to " + merged_clip)
 
-        save_dir = os.path.join(os.path.dirname(manimlib.addon_helper.movie_paths[0]), scene_name + ".pptx")
+        save_dir = os.path.join(os.path.dirname(manimlib.addon_helper.movie_paths[0]), ppt_name + ".pptx")
         slide_layout = prs.slide_layouts[SLD_BLANK]
-        for file in sorted(glob.glob(os.path.join(read_parts, "*.mp4"))):
-            self.log_line("Using file at " + file)
-            # Load the example presentation and its timing element
-            prs_ex = Presentation(self.EXAMPLE_PPTX)
-            timing_ex = prs_ex.slides[0].element[2]
-            self.log_line("\tGrabbed timing element, timing_ex = " + str(timing_ex))
-            # Create a new slide
-            slide = prs.slides.add_slide(slide_layout)
-            # Generate video thumbnail
-            thumb_file = os.path.join(Addon.TEMPORARY_DIR, self.get_name(file) + ".png")
-            self.log_line("\tGenerating video thumbnail...")
-            self.get_video_thumb(file, thumb_file)
-            self.log_line("\tThumbnail saved at " + thumb_file)
+        for part_dir in read_parts:
+            for file in sorted(glob.glob(os.path.join(part_dir, "*.mp4"))):
+                self.log_line(f"Using file at {file}")
+                # Load the example presentation and its timing element
+                prs_ex = Presentation(Addon.EXAMPLE_PPTX)
+                timing_ex = prs_ex.slides[0].element[2]
+                self.log_line(f"\tGrabbed timing element, timing_ex = {timing_ex}")
+                # Create a new slide
+                slide = prs.slides.add_slide(slide_layout)
+                # Generate video thumbnail
+                thumb_file = os.path.join(Addon.TEMPORARY_DIR, self.get_name(file) + ".png")
+                self.log_line("\tGenerating video thumbnail...")
+                self.get_video_thumb(file, thumb_file)
+                self.log_line(f"\tThumbnail saved at {thumb_file}")
 
-            # Add the video to the slide
-            clip = slide.shapes.add_movie(file, 0, 0, prs.slide_width, prs.slide_height, mime_type='video/mp4', poster_frame_image=thumb_file)
-            self.log_line("\tAdded clip to slide")
+                # Add the video to the slide
+                clip = slide.shapes.add_movie(file, 0, 0, prs.slide_width, prs.slide_height, mime_type='video/mp4', poster_frame_image=thumb_file)
+                self.log_line("\tAdded clip to slide")
 
-            # Play the clip in fullscreen when the slide starts
-            ## Get the id of the movie object we just added
-            id = clip.element[0][0].attrib.get("id")
-            self.log_line("\tClip id = " + id)
-            ## Make a copy of the timing element from the manually created PPTX,
-            ## then change every spid to the clip id
-            self.log_line("\tUsing timing_ex as template...")
-            timing = timing_ex
-            timing[0][0][0][0][0][0][0][0][0][1][0][0][1][0][0][1][0][0][1][0].attrib["spid"] = id
-            timing[0][0][0][0][1][0][1][0].attrib["spid"] = id
-            timing[0][0][0][0][2][0][0][0][0][0].attrib["spid"] = id
-            timing[0][0][0][0][2][0][2][0][0][1][0][0][1][0][0][1][0][0][1][0].attrib["spid"] = id
-            timing[0][0][0][0][2][1][0][0][0].attrib["spid"] = id
-            slide.element[2] = timing
-            self.log_line("\tAdded timing to slide, timing = " + str(timing))
-            prs.save(save_dir)
-            self.log_line("\tPPTX saved to " + save_dir)
+                # Play the clip in fullscreen when the slide starts
+                ## Get the id of the movie object we just added
+                id = clip.element[0][0].attrib.get("id")
+                self.log_line(f"\tClip id = {id}")
+                ## Make a copy of the timing element from the manually created PPTX,
+                ## then change every spid to the clip id
+                self.log_line("\tUsing timing_ex as template...")
+                timing = timing_ex
+                timing[0][0][0][0][0][0][0][0][0][1][0][0][1][0][0][1][0][0][1][0].attrib["spid"] = id
+                timing[0][0][0][0][1][0][1][0].attrib["spid"] = id
+                timing[0][0][0][0][2][0][0][0][0][0].attrib["spid"] = id
+                timing[0][0][0][0][2][0][2][0][0][1][0][0][1][0][0][1][0][0][1][0].attrib["spid"] = id
+                timing[0][0][0][0][2][1][0][0][0].attrib["spid"] = id
+                slide.element[2] = timing
+                self.log_line(f"\tAdded timing to slide, timing = {timing}")
+                prs.save(save_dir)
+                self.log_line(f"\tPPTX saved to {save_dir}")
         
-        self.log_line("Final presentation saved to " + save_dir)
-        print("\nPresentation ready at " + save_dir)
+        self.log_line(f"Final presentation saved to {save_dir}")
+        print(f"\nPresentation ready at {save_dir}")
         if self.config["all_args"].preview:
             self.open_file(save_dir)
 


### PR DESCRIPTION
This PR adds support for **dynamically specified scenes** by accepting them directly as a parameter instead of reading them of the config.

E.g. if the user previously invoked manim without a scene parameter:

>`python3 -m manim script.py --save_to_pptx`

...manim would prompt the user for the scenes to be rendered. These were, however, not written to the global config object and thus caused this addon to crash.

Instead, the render-related handlers now accept a list of scene classes, which accurately reflect the actual scenes rendered by the engine:

```python
def on_rendered(self, scene_classes):
    ...
```
Additionally, this PR adds a new flag which **combines all rendered scene classes into a single presentation** (`--join_scenes_pptx`).

Note that https://github.com/yoshiask/manim/pull/6 has to be merged first, since that PR includes the necessary changes to manim's API.